### PR TITLE
Use 1.x stable of redux-api-middleware. Handle "pending failure".

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
     "sinon": "~1.17.2",
     "sinon-chai": "~2.8.0",
     "npm-check-updates": "~2.5.4",
-    "redux-api-middleware": "github:vgno/redux-api-middleware#v1.0.0-beta4",
+    "redux-api-middleware": "~1.0.2",
     "codeclimate-test-reporter": "~0.1.1",
     "coveralls": "~2.11.4"
   },
   "peerDependencies": {
-    "redux-api-middleware": "github:vgno/redux-api-middleware#v1.0.0-beta4"
+    "redux-api-middleware": "~1.0.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export function createFetchReducer(id) {
 
     const actionPrefix = id.toUpperCase();
 
-    return (state = {}, { type, payload, meta }) => {
+    return (state = {}, { type, payload, meta, error }) => {
         if (type === actionPrefix + '_FETCH_SUCCESS') {
             return fetchSuccess(payload, meta);
         }
@@ -65,7 +65,7 @@ export function createFetchReducer(id) {
         }
 
         if (type === actionPrefix + '_FETCH_PENDING') {
-            return fetchPending(payload, meta);
+            return fetchPending(payload, meta, error);
         }
 
         return state;

--- a/src/util-reducer.js
+++ b/src/util-reducer.js
@@ -19,10 +19,10 @@ export function fetchFailure(payload, meta) {
 }
 
 // pending fetches indicate loading and exposes the pending endpoint
-export function fetchPending(payload, meta) {
+export function fetchPending(payload, meta, error = false) {
     return {
-        loading: true,
-        error: false,
+        loading: !error,
+        error,
         payload,
         meta
     };

--- a/test/index.js
+++ b/test/index.js
@@ -268,6 +268,31 @@ describe('redux-fetcher', () => {
                 state.meta.endpoint.should.be.equal('http://localhost/api');
             });
 
+            it('must return object containing payload with ' +
+                'name and message of error and payload in meta with no loading on fetch pending failure', () => {
+                const errorPayload = {
+                    name: 'errorname',
+                    message: 'errormessage'
+                };
+
+                const state = reducer(
+                    {},
+                    {
+                        type: 'DATA_FETCH_PENDING',
+                        meta: {
+                            endpoint: 'http://localhost/api'
+                        },
+                        payload: errorPayload,
+                        error: true
+                    }
+                );
+
+                state.loading.should.be.equal(false);
+                state.error.should.be.equal(true);
+                state.payload.should.be.equal(errorPayload);
+                state.meta.endpoint.should.be.equal('http://localhost/api');
+            });
+
             it('must return endpoint in meta with no error and active loading on fetch pending', () => {
                 const endpoint = 'http://localhost/awesomeendpoint';
                 const state = reducer({}, {


### PR DESCRIPTION
- Uses stable redux-api-middleware 1.x
- This will be a new major release as it sets the peerDependency "redux-api-middleware" to use one that has a breaking change with our fork.
- Updated project to handle "pending failure" correctly as redux-api-middleware expects. Transport errors and similar will dispatch a *_PENDING with error data, instead of a *_FAILURE.

redux-api-middleware will introduce the modifications in our fork in an official release in the _future_. Probably through 2.x. At that point we will consider following up with a new major of redux-fetcher. **Until then it is best to avoid maintaining a separate fork**, hence this PR.
