### PR TITLE
Allow passing custom meta

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,11 +15,22 @@ import { fetchSuccess, fetchFailure, fetchPending } from './util-reducer';
   * @param {string} [id] - identifier for the action
   * @param {string} [url] - url to fetch
   * @param {object} [options] - options to consider when creating action
+  * @param {object|function} [meta] - an object with data to put in the FSA
+                                      action or a function to calculate it
+                                      with the following signature:
+                                      (action, state, response) -> object
   * @returns {object} - redux-api-middleware compatible action
   */
-export function createFetchAction(id, url, options = { force: false, method: 'GET', body: '' }) {
+export function createFetchAction(id, url, options = { force: false, method: 'GET', body: '' }, meta = {}) {
     if (!id || !url) {
         throw new Error('Must provide action identifier and url');
+    }
+
+    let metaFunction;
+    if (typeof meta === 'function') {
+        metaFunction = meta;
+    } else {
+        metaFunction = () => meta;
     }
 
     const actionPrefix = id.toUpperCase();
@@ -30,9 +41,9 @@ export function createFetchAction(id, url, options = { force: false, method: 'GE
         bailout,
         method: options.method,
         types: [
-            createPendingType(actionPrefix, url),
-            createSuccessType(actionPrefix, url),
-            createFailureType(actionPrefix, url)
+            createPendingType(actionPrefix, url, metaFunction),
+            createSuccessType(actionPrefix, url, metaFunction),
+            createFailureType(actionPrefix, url, metaFunction)
         ]
     };
 

--- a/src/util-action.js
+++ b/src/util-action.js
@@ -8,7 +8,7 @@ export function createDefaultBailout(id, force) {
     };
 }
 
-export function createSuccessType(prefix, url) {
+export function createSuccessType(prefix, url, meta) {
     return {
         type: prefix + '_FETCH_SUCCESS',
         meta: (action, state, res) => {
@@ -17,24 +17,26 @@ export function createSuccessType(prefix, url) {
                 response: {
                     status: res.status,
                     type: res.type
-                }
+                },
+                ...meta(action, state, res)
             };
         }
     };
 }
 
-export function createPendingType(prefix, url) {
+export function createPendingType(prefix, url, meta) {
     return {
         type: prefix + '_FETCH_PENDING',
-        meta: () => {
+        meta: (action, state, res) => {
             return {
-                endpoint: url
+                endpoint: url,
+                ...meta(action, state, res)
             };
         }
     };
 }
 
-export function createFailureType(prefix, url) {
+export function createFailureType(prefix, url, meta) {
     return {
         type: prefix + '_FETCH_FAILURE',
         meta: (action, state, res) => {
@@ -44,11 +46,13 @@ export function createFailureType(prefix, url) {
                     response: {
                         status: res.status,
                         type: res.type
-                    }
+                    },
+                    ...meta(action, state, res)
                 };
             }
             return {
-                endpoint: url
+                endpoint: url,
+                ...meta(action, state, res)
             };
         }
     };

--- a/test/index.js
+++ b/test/index.js
@@ -185,6 +185,46 @@ describe('redux-fetcher', () => {
 
                 overridenAction.method.should.be.equal('POST');
             });
+
+            it('must pass on custom meta object to the action types', () => {
+                const metaObject = { exampleKey: 'exampleValue' };
+
+                const actionWithMeta = reduxFetcher.createFetchAction(
+                  'dataCamelCase',
+                  'http://localhost/api4',
+                  undefined,
+                  metaObject)[CALL_API];
+
+                const res = {
+                    status: 200,
+                    type: 'cors'
+                };
+
+                actionWithMeta.types[0].meta(actionWithMeta, {}, res).exampleKey.should.be.equal('exampleValue');
+                actionWithMeta.types[1].meta(actionWithMeta, {}, res).exampleKey.should.be.equal('exampleValue');
+                actionWithMeta.types[2].meta(actionWithMeta, {}, res).exampleKey.should.be.equal('exampleValue');
+                actionWithMeta.types[2].meta(actionWithMeta, {}, undefined).exampleKey.should.be.equal('exampleValue');
+            });
+
+            it('must pass on custom meta function to the action types', () => {
+                const metaFunction = () => ({ exampleKey: 'exampleValue' });
+
+                const actionWithMeta = reduxFetcher.createFetchAction(
+                  'dataCamelCase',
+                  'http://localhost/api4',
+                  undefined,
+                  metaFunction)[CALL_API];
+
+                const res = {
+                    status: 200,
+                    type: 'cors'
+                };
+
+                actionWithMeta.types[0].meta(actionWithMeta, {}, res).exampleKey.should.be.equal('exampleValue');
+                actionWithMeta.types[1].meta(actionWithMeta, {}, res).exampleKey.should.be.equal('exampleValue');
+                actionWithMeta.types[2].meta(actionWithMeta, {}, res).exampleKey.should.be.equal('exampleValue');
+                actionWithMeta.types[2].meta(actionWithMeta, {}, undefined).exampleKey.should.be.equal('exampleValue');
+            });
         });
 
         describe('createFetchReducer', () => {


### PR DESCRIPTION
This PR adds the possibility to provide custom `meta` data to the actions.

This possibility exists in `redux-api-middleware` so there are use cases for it but `redux-fetcher` hides this functionality making it impossible to provide custom `meta` data.

One example use case I can think of is writing down a lower-level `id` of the resource being fetched (e.g. an article ID) which can be helpful in determining whether to bail or not.
