### PR TITLE
Extend options object with defaults

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ import { fetchSuccess, fetchFailure, fetchPending } from './util-reducer';
                                       (action, state, response) -> object
   * @returns {object} - redux-api-middleware compatible action
   */
-export function createFetchAction(id, url, options = { force: false, method: 'GET', body: '' }, meta = {}) {
+export function createFetchAction(id, url, options = {}, meta = {}) {
     if (!id || !url) {
         throw new Error('Must provide action identifier and url');
     }
@@ -33,13 +33,24 @@ export function createFetchAction(id, url, options = { force: false, method: 'GE
         metaFunction = () => meta;
     }
 
+    const defaults = {
+        force: false,
+        method: 'GET',
+        body: ''
+    };
+
+    const settings = {
+        ...defaults,
+        ...options
+    };
+
     const actionPrefix = id.toUpperCase();
 
-    const bailout = options.bailout || createDefaultBailout(id, options.force);
+    const bailout = settings.bailout || createDefaultBailout(id, settings.force);
     const baseAction = {
         endpoint: url,
         bailout,
-        method: options.method,
+        method: settings.method,
         types: [
             createPendingType(actionPrefix, url, metaFunction),
             createSuccessType(actionPrefix, url, metaFunction),
@@ -48,7 +59,7 @@ export function createFetchAction(id, url, options = { force: false, method: 'GE
     };
 
     const middlewareAction = {
-        [CALL_API]: extendAction(baseAction, options)
+        [CALL_API]: extendAction(baseAction, settings)
     };
 
     return middlewareAction;

--- a/test/index.js
+++ b/test/index.js
@@ -225,6 +225,14 @@ describe('redux-fetcher', () => {
                 actionWithMeta.types[2].meta(actionWithMeta, {}, res).exampleKey.should.be.equal('exampleValue');
                 actionWithMeta.types[2].meta(actionWithMeta, {}, undefined).exampleKey.should.be.equal('exampleValue');
             });
+
+            it('must only override individual parameters from options', () => {
+                const overridenAction = reduxFetcher.createFetchAction('data', 'http://localhost/api', {
+                    force: true
+                })[CALL_API];
+
+                overridenAction.method.should.be.equal('GET');
+            });
         });
 
         describe('createFetchReducer', () => {


### PR DESCRIPTION
Using defaultds as a function parameter causes the whole options object to
be overriden, even when the intent is to change just one parameter.

Using `Object.assign()` allows a overriding only individual options

An alternative could be using destructing with defaults as the function argument
like this: `(id, url, { force = false, method = 'GET' } = {})`, but that
requires to also set default values for the `extendAction()` function
(`headers` and `credentials`).

Resolves #14
